### PR TITLE
feat: cli: flag for coloured log levels and flag for output to log file 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +209,16 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cgmath"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +226,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -236,6 +252,15 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "colored"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -509,6 +534,15 @@ dependencies = [
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fern"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -874,6 +908,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1411,6 +1446,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ring"
@@ -1991,11 +2031,13 @@ dependencies = [
 name = "whisper-cli"
 version = "0.1.0"
 dependencies = [
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-network 1.12.0 (git+https://github.com/paritytech/parity-ethereum.git)",
  "ethcore-network-devp2p 1.12.0 (git+https://github.com/paritytech/parity-ethereum.git)",
  "ethkey 0.3.0 (git+https://github.com/paritytech/parity-ethereum.git)",
+ "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-http-server 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-pubsub 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2054,6 +2096,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "winconsole"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,6 +2157,7 @@ dependencies = [
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 "checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum attohttpc 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf0ec4b0e00f61ee75556ca027485b7b354f4a714d88cc03f4468abd9378c86"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
@@ -2123,10 +2177,12 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "2ca4386c8954b76a8415b63959337d940d724b336cabd3afe189c2b51a7e1ff0"
+"checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
@@ -2151,6 +2207,7 @@ dependencies = [
 "checksum ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62d1bc682337e2c5ec98930853674dd2b4bd5d0d246933a9e98e5280f7c76c5f"
 "checksum ethkey 0.3.0 (git+https://github.com/paritytech/parity-ethereum.git)" = "<none>"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "29d26fa0f4d433d1956746e66ec10d6bf4d6c8b93cd39965cceea7f7cc78c7dd"
 "checksum fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -2247,6 +2304,7 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d8297cc20bbb6184f8b45ff61c8ee6a9ac56c156cec8e38c3e5084773c44ad"
 "checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
+"checksum rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "4f089652ca87f5a82a62935ec6172a534066c7b97be003cc8f702ee9a7a59c92"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rlp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0d56c1450bfbef1181fdeb78b902dc1d23178de77c23d705317508e03d1b7c"
@@ -2323,6 +2381,7 @@ dependencies = [
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum xmltree 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8eaee9d17062850f1e6163b509947969242990ee59a35801af437abe041e70"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Options:
 	-p, --port PORT                Specify which P2P port to use [default: random].
 	-a, --address ADDRESS          Specify which P2P address to use [default: 127.0.0.1].
 	-s, --secret KEYFILE           Specify which file contains the key to generate the enode.
-    -P, --rpc-port PORT            Specify which RPC port to use [default: 8545].
-    -A, --rpc-address ADDRESS      Specify which RPC address to use [default: 127.0.0.1].
-	-l, --log LEVEL                Specify the logging level. Must conform to the same format as RUST_LOG [default: Error].
+	-P, --rpc-port PORT            Specify which RPC port to use [default: 8545].
+	-A, --rpc-address ADDRESS      Specify which RPC address to use [default: 127.0.0.1].
+	-l, --logging LEVEL            Specify the logging level. Must conform to the same format as RUST_LOG [default: 0]. Log level verbosity configuration choice from highest to lowest priority (error 0, warn 1, info 2, debug 3, trace 4).
+	-L, --logging-to-file          Record logs to output.log file.
 	-h, --help                     Display this message and exit.
 ```
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,14 +6,16 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0"
 
 [dependencies]
+chrono = { version = "0.4.6", features = ["serde"] }
 docopt = "1.0"
 env_logger = "0.5"
 ethcore-network = { git = "https://github.com/paritytech/parity-ethereum.git" }
 ethcore-network-devp2p = { git = "https://github.com/paritytech/parity-ethereum.git" }
+fern = { version = "0.5", features = ["colored"] }
 jsonrpc-core = "12.0.0"
 jsonrpc-http-server = "12.0.0"
 jsonrpc-pubsub = "12.0.0"
-log = "0.4"
+log = { version = "0.4", features = ["std", "serde", "max_level_trace", "release_max_level_info"] }
 panic_hook = { git = "https://github.com/paritytech/parity-ethereum.git" }
 parity-whisper = { path = "../" }
 serde = "1.0"

--- a/cli/src/config/logger.rs
+++ b/cli/src/config/logger.rs
@@ -1,0 +1,113 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+use fern::colors::{Color, ColoredLevelConfig};
+use rlog::{LevelFilter};
+use std::io;
+
+fn setup_logger(verbosity: u32, logging_to_file: bool) -> Result<(), fern::InitError> {
+	let colors_line = ColoredLevelConfig::new()
+		.error(Color::Red)
+		.warn(Color::Yellow)
+		.info(Color::BrightBlack)
+		.debug(Color::BrightBlack)
+		.trace(Color::BrightBlack);
+
+	let colors_level = colors_line.clone().info(Color::Green);
+
+	let mut base_config = fern::Dispatch::new();
+
+	base_config = match verbosity {
+		0 => {
+			base_config
+			.level(LevelFilter::Error)
+			.level_for("pretty_colored", LevelFilter::Error)
+		}
+		1 => {
+			base_config
+			.level(LevelFilter::Warn)
+			.level_for("pretty_colored", LevelFilter::Warn)
+		},
+		2 => {
+			base_config
+			.level(LevelFilter::Info)
+			.level_for("pretty_colored", LevelFilter::Info)
+		},
+		3 => {
+			base_config
+			.level(LevelFilter::Debug)
+			.level_for("pretty_colored", LevelFilter::Debug)
+		},
+		_ => {
+			base_config
+			.level(LevelFilter::Trace)
+			.level_for("pretty_colored", LevelFilter::Trace)
+		},
+	};
+
+	let format_config = fern::Dispatch::new()
+		.format(move |out, message, record| {
+			out.finish(format_args!(
+				"{color_line}[{date}][{target}][{level}{color_line}] {message}\x1B[0m",
+				color_line = format_args!("\x1B[{}m", colors_line.get_color(&record.level()).to_fg_str()),
+				date = chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+				level = colors_level.color(record.level()),
+				target = record.target(),
+				message = message
+			))
+		})
+		.chain(io::stdout());
+
+	if logging_to_file {
+		let file_config = fern::Dispatch::new()
+			.format(|out, message, record| {
+				out.finish(format_args!(
+				"{}[{}][{}] {}",
+				chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+				record.level(),
+				record.target(),
+				message
+				))
+			})
+			.chain(fern::log_file("output.log")?);
+
+		base_config.chain(file_config).chain(format_config).apply()?;
+	} else {
+		base_config.chain(format_config).apply()?;
+	}
+
+  Ok(())
+}
+
+/// Initialisation of the [Log Crate](https://crates.io/crates/log) and [Fern Crate](https://docs.rs/fern/0.5.5/fern/)
+///
+/// - Choice of logging level verbosity from CLI: error (0), warn (1), info (2), debug (3), or trace (4).
+/// - Fallback to default logging level that is defined.
+/// - Use of logging level macros from highest priority to lowest: `error!`, `warn!`, `info!`, `debug!` and `trace!`.
+/// - [Compile time filters](https://docs.rs/log/0.4.1/log/#compile-time-filters) that override the CLI logging levels
+/// are configured in Cargo.toml. In production the max logging level may differ from in development.
+/// - Output to output.log when logging_to_file is true.
+pub fn init_logger(logging: &str, logging_to_file: bool) -> () {
+	let verbosity: u32 = logging.parse::<u32>().expect("parsing cannot fail; qed");
+
+	match setup_logger(verbosity, logging_to_file) {
+		Ok(_) => {
+			println!("Success initializing logger. Verbosity: {:?}. Log to file: {}", verbosity, &logging_to_file);
+			()
+		}
+		Err(e) => { println!("Error initializing logger: {}", e); }
+	}
+}

--- a/cli/src/config/mod.rs
+++ b/cli/src/config/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Whisper logger configuration.
+
+pub mod logger;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,16 +16,34 @@
 
 //! Whisper command line interface
 //!
+//! ## Overview
+//!
 //! Spawns an Ethereum network instance and attaches the Whisper protocol RPCs to it.
 //!
+//! ## Usage
+//!
+//! Whisper is distributed with regular Parity Ethereum releases so it may be run with:
+//!
+//! ```bash
+//! whisper --help
+//! ```
+//!
+//! Alternatively build it from source like so:
+//!
+//! ```bash
+//! cargo build -p whisper-cli --release
+//! ./target/release/whisper --help
+//! ```
 
 #![warn(missing_docs)]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
 
+extern crate chrono;
 extern crate docopt;
 extern crate env_logger;
 extern crate ethcore_network as net;
 extern crate ethcore_network_devp2p as devp2p;
+extern crate fern;
 extern crate panic_hook;
 extern crate parity_whisper as whisper;
 extern crate serde;
@@ -52,6 +70,8 @@ use std::str::FromStr;
 use ethkey::Secret;
 use rustc_hex::FromHex;
 
+mod config;
+
 const POOL_UNIT: usize = 1024 * 1024;
 const USAGE: &'static str = r#"
 Parity Whisper-v2 CLI.
@@ -68,11 +88,12 @@ Options:
 	-s, --secret KEYFILE           Specify which file contains the key to generate the enode.
 	-P, --rpc-port PORT            Specify which RPC port to use [default: 8545].
 	-A, --rpc-address ADDRESS      Specify which RPC address to use [default: 127.0.0.1].
-	-l, --log LEVEL                Specify the logging level. Must conform to the same format as RUST_LOG [default: Error].
+	-l, --logging LEVEL            Specify the logging level. Must conform to the same format as RUST_LOG [default: 0]. Log level verbosity configuration choice from highest to lowest priority (error 0, warn 1, info 2, debug 3, trace 4).
+	-L, --logging-to-file          Record logs to output.log file.
 	-h, --help                     Display this message and exit.
 "#;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Deserialize)]
 struct Meta;
 
 impl Metadata for Meta {}
@@ -90,7 +111,8 @@ struct Args {
 	flag_address: String,
 	flag_rpc_port: String,
 	flag_rpc_address: String,
-	flag_log: String,
+	flag_logging: String,
+	flag_logging_to_file: bool,
 	flag_secret: String,
 }
 
@@ -226,7 +248,8 @@ fn execute<S, I>(command: I) -> Result<(), Error> where I: IntoIterator<Item=S>,
 	let pool_size = args.flag_whisper_pool_size * POOL_UNIT;
 	let rpc_url = format!("{}:{}", args.flag_rpc_address, args.flag_rpc_port);
 
-	initialize_logger(args.flag_log);
+	// Default values are defined in the CLI configuration
+	config::logger::init_logger(&args.flag_logging, args.flag_logging_to_file);
 	info!(target: "whisper-cli", "start");
 
 	// Filter manager that will dispatch `decryption tasks`
@@ -288,12 +311,6 @@ fn execute<S, I>(command: I) -> Result<(), Error> where I: IntoIterator<Item=S>,
 
 	// This will never return if the http server runs without errors
 	Ok(())
-}
-
-fn initialize_logger(log_level: String) {
-	env_logger::Builder::from_env(env_logger::Env::default())
-		.parse(&log_level)
-		.init();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- [x] Apply same changes that were made in [PR #10810](https://github.com/paritytech/parity-ethereum/pull/10810) to parity-ethereum codebase before the module was split into a separate repo
- [ ] Fix the following error that is now produced since [the PR to update jsonrpc from 10.0 to 12.0](https://github.com/paritytech/parity-ethereum/pull/10841)

```
$ cargo build -p whisper-cli
   Compiling whisper-cli v0.1.0 (/Users/Ls/code/blockchain/clones/paritytech/whisper/cli)
error[E0277]: the trait bound `Meta: std::default::Default` is not satisfied
   --> cli/src/main.rs:306:15
    |
306 |     let server = jsonrpc_http_server::ServerBuilder::new(io)
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `Meta`
    |
    = note: required by `jsonrpc_http_server::ServerBuilder::<M, S>::new`
```
