### PR TITLE
Update bitflags from 0.9 to 1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -227,7 +222,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -537,7 +532,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1109,7 +1104,7 @@ dependencies = [
 name = "parity-whisper"
 version = "0.1.0"
 dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-network 1.12.0 (git+https://github.com/paritytech/parity-ethereum.git)",
  "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2067,7 +2062,7 @@ name = "xml-rs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2111,8 +2106,7 @@ dependencies = [
 "checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
 "checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-bitflags = "0.9"
+bitflags = "1.2"
 byteorder = "1.0.0"
 ethereum-types = "0.6.0"
 ethcore-network = { git = "https://github.com/paritytech/parity-ethereum.git" }

--- a/src/rpc/payload.rs
+++ b/src/rpc/payload.rs
@@ -52,10 +52,10 @@ bitflags! {
 
 // number of bytes of padding length (in the range 0..4)
 fn padding_length_bytes(flags: Flags) -> usize {
-	match (flags & FLAG_PAD_LEN_HIGH, flags & FLAG_PAD_LEN_LOW) {
-		(FLAG_PAD_LEN_HIGH, FLAG_PAD_LEN_LOW) => 3,
-		(FLAG_PAD_LEN_HIGH, _) => 2,
-		(_, FLAG_PAD_LEN_LOW) => 1,
+	match (flags & Flags::FLAG_PAD_LEN_HIGH, flags & Flags::FLAG_PAD_LEN_LOW) {
+		(Flags::FLAG_PAD_LEN_HIGH, Flags::FLAG_PAD_LEN_LOW) => 3,
+		(Flags::FLAG_PAD_LEN_HIGH, _) => 2,
+		(_, Flags::FLAG_PAD_LEN_LOW) => 1,
 		(_, _) => 0,
 	}
 }
@@ -136,7 +136,7 @@ pub fn encode(params: EncodeParams) -> Result<Vec<u8>, &'static str> {
 
 		if let Some(ref sig) = signature {
 			plaintext_size += sig.len();
-			flags |= FLAG_SIGNED;
+			flags |= Flags::FLAG_SIGNED;
 		}
 
 		(flags, plaintext_size)
@@ -202,7 +202,7 @@ pub fn decode(payload: &[u8]) -> Result<Decoded, &'static str> {
 			None
 		};
 
-		let signature = if flags & FLAG_SIGNED == FLAG_SIGNED {
+		let signature = if flags & Flags::FLAG_SIGNED == Flags::FLAG_SIGNED {
 			let slice = next_slice(SIGNATURE_LEN)?;
 			let mut arr = [0; SIGNATURE_LEN];
 
@@ -252,9 +252,9 @@ mod tests {
 	fn padding_len_bytes_sanity() {
 		const U24_MAX: usize = (1 << 24) - 1;
 
-		assert_eq!(padding_length_bytes(FLAG_PAD_LEN_HIGH | FLAG_PAD_LEN_LOW), 3);
-		assert_eq!(padding_length_bytes(FLAG_PAD_LEN_HIGH), 2);
-		assert_eq!(padding_length_bytes(FLAG_PAD_LEN_LOW), 1);
+		assert_eq!(padding_length_bytes(Flags::FLAG_PAD_LEN_HIGH | Flags::FLAG_PAD_LEN_LOW), 3);
+		assert_eq!(padding_length_bytes(Flags::FLAG_PAD_LEN_HIGH), 2);
+		assert_eq!(padding_length_bytes(Flags::FLAG_PAD_LEN_LOW), 1);
 		assert_eq!(padding_length_bytes(Flags::empty()), 0);
 
 		assert!(num_padding_length_bytes(u32::max_value() as _).is_none());


### PR DESCRIPTION
v0.9 causes build warnings due to the usage of deprecated item `try!`:

```sh
$ cargo build

   Compiling parity-whisper v0.1.0 (/Users/akihito1/src/github.com/ackintosh/whisper)
warning: use of deprecated item 'try': use the `?` operator instead
  --> src/rpc/payload.rs:45:1
   |
45 | / bitflags! {
46 | |     struct Flags: u8 {
47 | |         const FLAG_PAD_LEN_HIGH = 0b10000000;
48 | |         const FLAG_PAD_LEN_LOW  = 0b01000000;
49 | |         const FLAG_SIGNED       = 0b00100000;
50 | |     }
51 | | }
   | |_^
   |
   = note: `#[warn(deprecated)]` on by default
   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

CHANGELOG: https://github.com/bitflags/bitflags/blob/master/CHANGELOG.md